### PR TITLE
Fixed checking magic quotes and simplified checking register globals

### DIFF
--- a/Shield/Env.php
+++ b/Shield/Env.php
@@ -34,8 +34,7 @@ class Env extends Base
      */
     private function checkRegisterGlobals()
     {
-        $reg = ini_get('register_globals');
-        if ($reg != '' && $reg !== false && $false !== 0) {
+        if (ini_get('register_globals')) {
             $this->throwError('SECURITY WARNING: register_globals is enabled! '
                 .'Please consider disabling.');
         } else {
@@ -50,9 +49,7 @@ class Env extends Base
      */
     private function checkMagicQuotes()
     {
-        $quotes = ini_get('magic_quotes');
-
-        if ($quotes !== '' && $quotes !== false) {
+        if (get_magic_quotes_gpc() || get_magic_quotes_runtime()) {
             $this->throwError('SECURITY WARNING: magic_quotes is enabled! '
                 .'Please consider disabling');
         } else {


### PR DESCRIPTION
1. In PHP empty string, string "0", zero number and null in non-strict comparison are converted to false:
   http://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting
   http://php.net/manual/en/language.operators.comparison.php
   `$reg = ini_get('register_globals');if ($reg != '' && $reg !== false && $reg !== 0) {}` is equals to `if (ini_get('register_globals')) {}`, but second looks better.
2. `magic_quotes` directive does not exist.

``` ini
; Magic quotes for incoming GET/POST/Cookie data.
magic_quotes_gpc = Off
; Magic quotes for runtime-generated data, e.g. data from SQL, from exec(), etc.
magic_quotes_runtime = Off
; Use Sybase-style magic quotes (escape ' with '' instead of \').
magic_quotes_sybase = Off
```

For checking magic quotes you can use [get_magic_quotes_gpc()](http://www.php.net/manual/en/function.get-magic-quotes-gpc.php) || [get_magic_quotes_runtime()](http://www.php.net/manual/en/function.get-magic-quotes-runtime.php) or ini_get('magic_quotes_gpc') || ini_get('magic_quotes_runtime')
