### PR TITLE
Correcting an issue when multiple autoloaders are registered.

### DIFF
--- a/Shield/Shield.php
+++ b/Shield/Shield.php
@@ -143,8 +143,9 @@ class Shield
         $path = __DIR__.'/'.str_replace('Shield\\', '/', $className).'.php';
         if (is_file($path)) {
             include_once $path;
+            return true;
         } else {
-            $this->throwError('Could not load class: '.$className);
+           return false;
         }
     }
 


### PR DESCRIPTION
If multiple autoloaders are registered, `_load` will cause the propagation of the stack to stop if it cannot locate the class and not attempt any of the other autoloaders registered after the Shield loader has.  This is because of the error that is triggered.  When the system is running through the autoloader stack, it checks the return value of the registered callback.  If the value is `false` it will continue to the next loader is the stack, if it is `true` it will stop running down the stack (if `null`, or nothing, is returned, then it runs a check to see if the class exists, prior to moving on to the next loader).
